### PR TITLE
Fix GitHub actions workflows

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -3,15 +3,19 @@
 name: CI
 
 # Controls when the action will run. 
-on:
+on: 
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - fix/github-actions-workflows # Adding as test.
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - fix/github-actions-workflows # Adding as test.
 
   # Allows you to run this workflow manually from the Actions tab
-  # workflow_dispatch:
+  workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -8,11 +8,9 @@ on:
   push:
     branches:
       - master
-      - fix/github-actions-workflows # Adding as test.
   pull_request:
     branches:
       - master
-      - fix/github-actions-workflows # Adding as test.
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
I think this should fix it. After replacing this block:

```
on:
  push:
    branches: [ master ]
  pull_request:
    branches: [ master ]
```

With:

```
on:
  push:
    branches:
      - master
   pull_request:
     branches:
       - master
```

That seemed to allow the `master` branch GitHub Actions to trigger.